### PR TITLE
Add organisation wide pull request template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## What does this change?
+
+<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. -->
+
+## How to test
+
+<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
+
+## How can we measure success?
+
+<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
+
+## Have we considered potential risks?
+
+<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->
+


### PR DESCRIPTION
## What does this change?

This change add an [organisation level pull request template](https://www.rhysmills.com/post/2021/09/07/set-a-default-pr-template-for-a-github-organisation.html). 

The intention is to provide a simple template to encourage good documentation practise in pull requests, and to reduce the need to do this for new repositories.

_This is appreciatively cribbed from https://github.com/guardian/.github/blob/main/PULL_REQUEST_TEMPLATE.md_

## How to test

- [x] Merge this change, create a PR in a repository, does it work?

## How can we measure success?

Better documented PRs, happier developers.

## Have we considered potential risks?

The template here doesn't match expectation and is not useful for a particular project. In that case it can be overridden by a repository specific template.