### PR TITLE
stale PR workflow triggered on workflow_call

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,34 @@
+# Automatically mark any pull requests that have been inactive for 30 days as "Stale"
+# then close them 3 days later if there is still no activity.
+# 
+# Shamelessly copied from https://github.com/guardian/.github/blob/main/workflow-templates/stale.yml
+name: "Stale PR Handler"
+
+on: workflow_call
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        id: stale
+        # Read about options here: https://github.com/actions/stale#all-options
+        with:
+          # never automatically mark issues as stale
+          days-before-issue-stale: -1
+
+          # Wait 30 days before marking a PR as stale
+          days-before-stale: 30
+          stale-pr-message: >
+            This PR is stale because it has been open 30 days with no activity.
+            Unless a comment is added or the “stale” label removed, this will be closed in 3 days
+
+          # Wait 3 days after a PR has been marked as stale before closing
+          days-before-close: 3
+          close-pr-message: This PR was closed because it has been stalled for 3 days with no activity.
+
+          # Ignore PR's raised by Dependabot
+          exempt-pr-labels: "dependencies"


### PR DESCRIPTION
## What does this change?

Adds a reusable stale PR workflow in a directory where other repos can call it

## How to test

Merge https://github.com/wellcomecollection/content-api/pull/135. The github action in content-api should be able to run using this here workflow.yml

## How can we measure success?

See above

## Have we considered potential risks?

We don't need to merge this PR to see whether it works, as the "caller" repo points to this branch 

