### PR TITLE
add formatting gha workflow to be called by other repos

### DIFF
--- a/.github/workflows/scala_formatting.yml
+++ b/.github/workflows/scala_formatting.yml
@@ -46,6 +46,6 @@ jobs:
         run: |
           git config user.name "Github on behalf of Wellcome Collection"
           git config user.email "wellcomedigitalplatform@wellcome.ac.uk"
-          git commit -am "Apply auto-formatting rules [ci skip]"
+          git commit -am "Apply auto-formatting rules"
           git push
 

--- a/.github/workflows/scala_formatting.yml
+++ b/.github/workflows/scala_formatting.yml
@@ -1,8 +1,7 @@
 # Runs auto-formatting script on push to any branch
 name: "Run auto formatting"
 
-# not sure whether these need to be in the caller or called workflow
-
+# Unsure whether these need to be on the caller or called workflow
 # permissions:
 #   id-token: write
 #   contents: write

--- a/.github/workflows/scala_formatting.yml
+++ b/.github/workflows/scala_formatting.yml
@@ -1,0 +1,52 @@
+# Runs auto-formatting script on push to any branch
+name: "Run auto formatting"
+
+# not sure whether these need to be in the caller or called workflow
+
+# permissions:
+#   id-token: write
+#   contents: write
+
+on: workflow_call
+
+jobs:
+  autoformat:
+    name: autoformat
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out project
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        id: aws_credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: eu-west-1
+          role-to-assume: ${{ secrets.GHA_SCALA_FORMATTING_ROLE_ARN }}
+          output-credentials: true
+
+      - name: Log in to private ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Run formatting
+        run: bash ./builds/run_formatting.sh
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws_credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_KEY: ${{ steps.aws_credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws_credentials.outputs.aws-session-token }}
+
+      - name: Check for formatting changes
+        id: check_formatting_changes
+        run: |
+          if [[ -n $(git status --porcelain) ]]; then
+              echo "changes=true" >> "$GITHUB_OUTPUT"; 
+          fi
+
+      - name: Commit and push formatting changes
+        if: steps.check_formatting_changes.outputs.changes == 'true'
+        run: |
+          git config user.name "Github on behalf of Wellcome Collection"
+          git config user.email "wellcomedigitalplatform@wellcome.ac.uk"
+          git commit -am "Apply auto-formatting rules"
+          git push
+

--- a/.github/workflows/scala_formatting.yml
+++ b/.github/workflows/scala_formatting.yml
@@ -46,6 +46,6 @@ jobs:
         run: |
           git config user.name "Github on behalf of Wellcome Collection"
           git config user.email "wellcomedigitalplatform@wellcome.ac.uk"
-          git commit -am "Apply auto-formatting rules"
+          git commit -am "Apply auto-formatting rules [ci skip]"
           git push
 

--- a/.github/workflows/scala_formatting.yml
+++ b/.github/workflows/scala_formatting.yml
@@ -2,9 +2,9 @@
 name: "Run auto formatting"
 
 # Unsure whether these need to be on the caller or called workflow
-# permissions:
-#   id-token: write
-#   contents: write
+permissions:
+  id-token: write
+  contents: write
 
 on: workflow_call
 


### PR DESCRIPTION
## What does this change?

This workflow has been developed and tested in the [catalogue-api](https://github.com/wellcomecollection/catalogue-api/pull/804)
We want to add it here to reduce duplication, to be used by the caller repositories

## How to test

Update the .github/workflows/autoformat.yml files in caller repositories to call this workflow 

```
# Runs auto-formatting script on push to any branch
name: "Scala auto-formatting"

on: push

permissions:
  id-token: write
  contents: write

jobs:
  autoformat:
    uses: wellcomecollection/.github/.github/workflows/scala_formatting.yml@make-reformatting-workflow-reusable
    secrets: inherit // this to be changed to main once merged
```

## How can we measure success?

On push to any branch of a caller repository, the formatting job is run successfully

## Have we considered potential risks?

Failed checks can be ignored when merging.
