### PR TITLE
callable python lint workflow

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -5,7 +5,10 @@ on: workflow_call
 jobs:
   flake8-lint:
     runs-on: ubuntu-latest
+    name: Lint
     steps:
+      - name: Check out source repository
+        uses: actions/checkout@v3
       - name: Set up Python environment
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,14 @@
+name: "Python lint"
+
+on: workflow_call
+
+jobs:
+  flake8-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python environment
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: flake8 Lint
+        uses: py-actions/flake8@v2

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -15,3 +15,6 @@ jobs:
           python-version: "3.11"
       - name: flake8 Lint
         uses: py-actions/flake8@v2
+        with:
+          ignore: "E501","E122","E126","E203","W503"
+          exclude: ".git","__pycache__","target",".terraform","overlay"

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -16,5 +16,5 @@ jobs:
       - name: flake8 Lint
         uses: py-actions/flake8@v2
         with:
-          ignore: "E501","E122","E126","E203","W503"
-          exclude: ".git","__pycache__","target",".terraform","overlay"
+          ignore: "E501,E122,E126,E203,W503"
+          exclude: ".git,__pycache__,target,.terraform,overlay"


### PR DESCRIPTION
## What does this change?

Add a callable workflow that we can call from any project that needs it 

## How to test

Add a github workflow in say, catalogue-pipeline, to call this here workflow on [ push, pull_request ]. Upon opening the pull-request for the new workflow in catalogue-pipeline, the python linting action should be triggered

## How can we measure success?

The python lint action runs successfully in a caller repository

## Have we considered potential risks?

This can all run on feature branches for now so it's not affecting main or production systems

