### PR TITLE
Use paid runner default_x64_latest

### DIFF
--- a/.github/workflows/dependency_graph.yml
+++ b/.github/workflows/dependency_graph.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   dependency-graph:
     name: Update Dependency Graph
-    runs-on: ubuntu-latest
+    runs-on: default_x64_latest
     steps:
       - name: Install sbt
         uses: sbt/setup-sbt@v1

--- a/.github/workflows/scala_formatting.yml
+++ b/.github/workflows/scala_formatting.yml
@@ -11,7 +11,7 @@ on: workflow_call
 jobs:
   autoformat:
     name: autoformat
-    runs-on: ubuntu-latest
+    runs-on: default_x64_latest
     steps:
       - name: Check out project
         uses: actions/checkout@v4

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: default_x64_latest
     steps:
       - uses: actions/stale@v9
         id: stale


### PR DESCRIPTION
This pull request updates the runner configuration for multiple GitHub Actions workflows, replacing `ubuntu-latest` with `default_x64_latest` to align with the latest default runner setup.

Runner configuration updates:

* [`.github/workflows/dependency_graph.yml`](diffhunk://#diff-6ca8dbf86b037a2931255d7767efc224ce393b6f91fea55431db8a2974b1c4baL13-R13): Changed the `runs-on` parameter for the `dependency-graph` job from `ubuntu-latest` to `default_x64_latest`.
* [`.github/workflows/scala_formatting.yml`](diffhunk://#diff-e04009df82209411ced37a1a404ebd6989d090140b28412b8b6bdb6619560da5L14-R14): Changed the `runs-on` parameter for the `autoformat` job from `ubuntu-latest` to `default_x64_latest`.
* [`.github/workflows/stale.yml`](diffhunk://#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894L14-R14): Changed the `runs-on` parameter for the `stale` job from `ubuntu-latest` to `default_x64_latest`.