### PR TITLE
copy common python actions from catalogue-pipeline

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -1,0 +1,45 @@
+name: 'Docker build and push'
+description: "Builds and publishes a Docker image to ECR"
+inputs:
+  registry:
+    description: "ECR registry where the image is to be published"
+    required: true
+  folder:
+    description: "working folder"
+    required: true
+  target:
+    description: "target to build in a multistage docker"
+    required: true
+  tag:
+    description: "tag for the image"
+    required: true
+  role_to_assume:
+    description: "role to assume when pushing the image to ECR"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: build docker image
+      run: |
+        docker build . --build-arg pythonversion=$(cat .python-version) --tag "${{inputs.target}}:${{inputs.tag}}" --target "${{inputs.target}}"
+      working-directory: ${{inputs.folder}}
+      shell: bash
+
+    - name: publish versioned container to registry
+      uses: ./.github/actions/push_to_ecr
+      with:
+        registry: ${{inputs.registry}}
+        image_name: ${{inputs.target}}
+        local_tag: ${{inputs.tag}}
+        registry_tag: ${{inputs.tag}}
+        role_to_assume: ${{inputs.role_to_assume}}
+
+    - name: publish latest container to registry
+      uses: ./.github/actions/push_to_ecr
+      if: ${{ github.ref == 'refs/heads/main' }}
+      with:
+        registry: 760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome
+        image_name: ${{inputs.target}}
+        local_tag: ${{inputs.tag}}
+        registry_tag: latest
+        role_to_assume: ${{inputs.role_to_assume}}

--- a/.github/actions/push_to_ecr/action.yml
+++ b/.github/actions/push_to_ecr/action.yml
@@ -1,0 +1,36 @@
+name: 'Push to ECR'
+description: "Pushes a Docker image to an amazon ECR repository"
+inputs:
+  registry:
+    description: "URL of registry where the image will be pushed"
+    required: true
+  image_name:
+    description: "Name of the image to push"
+    required: true
+  local_tag:
+    description: "Tag of the local image"
+    required: true
+  registry_tag:
+    description: "Tag to be used for the image on the registry"
+    required: true
+  role_to_assume:
+    description: "role to assume when pushing the image to ECR"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: eu-west-1
+        role-to-assume: ${{ inputs.role_to_assume }}
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v2
+    - name: Push to ECR
+      shell: bash
+      run: |
+        docker tag "$LOCAL_FULLNAME" "$TARGET_FULLNAME"
+        docker push $TARGET_FULLNAME
+      env:
+        TARGET_FULLNAME: "${{inputs.registry}}/${{inputs.image_name}}:${{inputs.registry_tag}}"
+        LOCAL_FULLNAME: "${{inputs.image_name}}:${{inputs.local_tag}}"

--- a/.github/actions/python_check/action.yml
+++ b/.github/actions/python_check/action.yml
@@ -1,0 +1,36 @@
+name: 'Python Check'
+description: "Runs checks (linting, tests) on the python code within the given folder"
+inputs:
+  folder:
+    description: folder to check
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version-file: ${{ inputs.folder}}/.python-version
+    - name: setup dependencies
+      run: |
+        pip install uv
+        uv sync --all-groups
+      working-directory: ${{inputs.folder}}
+      shell: bash
+    - name: lint
+      run: uvx ruff check $FOLDER
+      shell: bash
+      env:
+        FOLDER: ${{inputs.folder}}
+    - name: test
+      id: test
+      run: |
+        set +e
+        uv run pytest
+        TEST_OUTPUT=$?
+        # 5 = No Tests Run.  Ideally, this would be a failure, but we 
+        # do have some projects with no tests, where it is still beneficial
+        # to "run the tests", as that proves that the code can be run.
+        if [[ TEST_OUTPUT -eq 5 ]]; then TEST_OUTPUT=0; fi
+        exit $TEST_OUTPUT
+      working-directory: ${{inputs.folder}}
+      shell: bash


### PR DESCRIPTION
## What does this change?

This makes some common actions, originally written for the inferrers in the catalogue pipeline, available for reuse in other repositories.

This is half of https://github.com/wellcomecollection/platform/issues/6083
## How to test

Create or modify a UV-based python project, use these actions to test and deploy it.

## How can we measure success?

This should help harmonise our various Python projects, and make it simpler to create new ones.

## Have we considered potential risks?

There are no risks associated with this PR, as it does nothing until actually referenced in a build pipeline.
