### PR TITLE
Common python ci tweak

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -16,6 +16,11 @@ inputs:
   role_to_assume:
     description: "role to assume when pushing the image to ECR"
     required: true
+  publish_latest:
+    description: "Whether to publish an image with the 'latest' tag"
+    required: false
+    type: 'boolean'
+    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -26,7 +31,7 @@ runs:
       shell: bash
 
     - name: publish versioned container to registry
-      uses: ./.github/actions/push_to_ecr
+      uses: wellcomecollection/.github/.github/actions/push_to_ecr
       with:
         registry: ${{inputs.registry}}
         image_name: ${{inputs.target}}
@@ -35,8 +40,9 @@ runs:
         role_to_assume: ${{inputs.role_to_assume}}
 
     - name: publish latest container to registry
-      uses: ./.github/actions/push_to_ecr
-      if: ${{ github.ref == 'refs/heads/main' }}
+      uses: wellcomecollection/.github/.github/actions/push_to_ecr
+      if: ${{ inputs.publish_latest }}
+#      if: ${{ github.ref == 'refs/heads/main' }}
       with:
         registry: 760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome
         image_name: ${{inputs.target}}

--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -31,7 +31,7 @@ runs:
       shell: bash
 
     - name: publish versioned container to registry
-      uses: wellcomecollection/.github/.github/actions/push_to_ecr
+      uses: wellcomecollection/.github/.github/actions/push_to_ecr@main
       with:
         registry: ${{inputs.registry}}
         image_name: ${{inputs.target}}
@@ -40,9 +40,8 @@ runs:
         role_to_assume: ${{inputs.role_to_assume}}
 
     - name: publish latest container to registry
-      uses: wellcomecollection/.github/.github/actions/push_to_ecr
+      uses: wellcomecollection/.github/.github/actions/push_to_ecr@main
       if: ${{ inputs.publish_latest }}
-#      if: ${{ github.ref == 'refs/heads/main' }}
       with:
         registry: 760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome
         image_name: ${{inputs.target}}


### PR DESCRIPTION
## What does this change?

Following the move of the common Python actions into this repository, there were two things I needed to resolve better:

1. It isn't really the business of this action to decide whether to push `latest`, that should be decided by the caller and passed in as a boolean
2. I was relying on checking this repository out as part of the build, so that build-and-push could call push-to-ecr.  This change allows the caller to treat it as a normal shared action.

 
## How to test

The corresponding [workflows in the catalogue pipeline](https://github.com/wellcomecollection/catalogue-pipeline/actions/runs/16413560923/job/46374176339?pr=2955) work as expected.

## How can we measure success?

Clearer workflow definitions when this action is used.  Explicit is better than Implicit.



